### PR TITLE
Add Chrome extension for copying special characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-Hello world

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "FastChar",
+  "version": "1.0.0",
+  "description": "Quickly copy special characters to the clipboard.",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "FastChar"
+  },
+  "permissions": [
+    "clipboardWrite"
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>FastChar</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+    }
+    #grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(30px, 1fr));
+      gap: 4px;
+      padding: 4px;
+    }
+    .char {
+      padding: 4px;
+      font-size: 20px;
+      text-align: center;
+      cursor: pointer;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+    }
+    .char:hover {
+      background: #f0f0f0;
+    }
+    #message {
+      text-align: center;
+      font-size: 12px;
+      padding-top: 4px;
+      height: 16px;
+    }
+  </style>
+</head>
+<body>
+  <div id="grid"></div>
+  <div id="message"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,27 @@
+const chars = ['—','–','°','±','·','×','÷','←','↑','→','↓','⇧','⇩','↔','↕','★','☆','♥','☺','☹','✓','✗'];
+
+const grid = document.getElementById('grid');
+const message = document.getElementById('message');
+
+chars.forEach(ch => {
+  const div = document.createElement('div');
+  div.textContent = ch;
+  div.className = 'char';
+  div.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(ch);
+      showMessage(`Copied ${ch}`);
+    } catch (err) {
+      showMessage('Failed to copy');
+      console.error(err);
+    }
+  });
+  grid.appendChild(div);
+});
+
+function showMessage(text) {
+  message.textContent = text;
+  setTimeout(() => {
+    message.textContent = '';
+  }, 1000);
+}


### PR DESCRIPTION
## Summary
- Define Chrome extension manifest with popup and clipboard permission
- Implement popup UI showing a grid of special characters
- Add script to copy characters to clipboard and show confirmation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aade96195483218a2199115b27d591