### PR TITLE
Display characters in table layout

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -9,15 +9,18 @@
       font-family: sans-serif;
     }
     #grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(30px, 1fr));
-      gap: 4px;
-      padding: 4px;
+      border-collapse: separate;
+      border-spacing: 4px;
+      margin: 4px;
+    }
+    #grid td {
+      width: 30px;
+      height: 30px;
+      text-align: center;
     }
     .char {
       padding: 4px;
       font-size: 20px;
-      text-align: center;
       cursor: pointer;
       border: 1px solid #ccc;
       border-radius: 4px;
@@ -35,30 +38,57 @@
   </style>
 </head>
 <body>
-  <div id="grid">
-    <div class="char">«</div>
-    <div class="char">»</div>
-    <div class="char">→</div>
-    <div class="char">←</div>
-    <div class="char">↑</div>
-    <div class="char">↓</div>
-    <div class="char">~</div>
-    <div class="char">≈</div>
-    <div class="char">≠</div>
-    <div class="char">≥</div>
-    <div class="char">≤</div>
-    <div class="char">₽</div>
-    <div class="char">$</div>
-    <div class="char">€</div>
-    <div class="char">×</div>
-    <div class="char">−</div>
-    <div class="char">±</div>
-    <div class="char">–</div>
-    <div class="char">—</div>
-    <div class="char">•</div>
-    <div class="char">©</div>
-    <div class="char">ツ</div>
-  </div>
+  <table id="grid">
+    <tr>
+      <td class="char">«</td>
+      <td class="char">»</td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td class="char">→</td>
+      <td class="char">←</td>
+      <td class="char">↑</td>
+      <td class="char">↓</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td class="char">~</td>
+      <td class="char">≈</td>
+      <td class="char">≠</td>
+      <td class="char">≥</td>
+      <td class="char">≤</td>
+    </tr>
+    <tr>
+      <td class="char">₽</td>
+      <td class="char">$</td>
+      <td class="char">€</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td class="char">×</td>
+      <td class="char">−</td>
+      <td class="char">±</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td class="char">–</td>
+      <td class="char">—</td>
+      <td class="char">•</td>
+      <td class="char">©</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td class="char">ツ</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </table>
   <div id="message"></div>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,9 +1,9 @@
 const grid = document.getElementById('grid');
 const message = document.getElementById('message');
 
-grid.querySelectorAll('.char').forEach(div => {
-  const ch = div.textContent;
-  div.addEventListener('click', async () => {
+grid.querySelectorAll('.char').forEach(cell => {
+  const ch = cell.textContent;
+  cell.addEventListener('click', async () => {
     try {
       await navigator.clipboard.writeText(ch);
       showMessage(`Copied ${ch}`);


### PR DESCRIPTION
## Summary
- Replaced the popup grid with a five-column table and added blank cells to mirror the desired character arrangement.
- Updated styles to size table cells consistently and keep character hover behavior.
- Adjusted JavaScript to target table cells rather than divs when copying characters to the clipboard.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0be0f7f883218fe5c084f345982b