### PR TITLE
feat: restore tabular layout

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -7,46 +7,33 @@
     body {
       margin: 0;
       font-family: sans-serif;
-      background: #fafafa;
     }
     #grid {
       border-collapse: separate;
       border-spacing: 4px;
       margin: 4px;
-      table-layout: fixed;
     }
     #grid td {
-      width: 40px;
-      height: 40px;
+      width: 30px;
+      height: 30px;
       text-align: center;
-      padding: 0;
     }
     .char {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      height: 100%;
+      padding: 4px;
       font-size: 20px;
       cursor: pointer;
       border: 1px solid #ccc;
-      border-radius: 6px;
+      border-radius: 4px;
       background: #fff;
-      box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-      transition: background 0.2s, transform 0.1s;
     }
     .char:hover {
-      background: #e0f0ff;
-      transform: translateY(-2px);
+      background: #f0f0f0;
     }
     #message {
       text-align: center;
       font-size: 12px;
       padding-top: 4px;
       height: 16px;
-      color: #555;
-      opacity: 0;
-      transition: opacity 0.3s;
     }
   </style>
 </head>

--- a/popup.js
+++ b/popup.js
@@ -16,11 +16,7 @@ grid.querySelectorAll('.char').forEach(cell => {
 
 function showMessage(text) {
   message.textContent = text;
-  message.style.opacity = 1;
-  setTimeout(() => {
-    message.style.opacity = 0;
-  }, 1000);
   setTimeout(() => {
     message.textContent = '';
-  }, 1300);
+  }, 1000);
 }


### PR DESCRIPTION
## Summary
- Restore simple table-based layout for popup grid
- Simplify copy message logic

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/fastcharext/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ab137971a883219d09b9e8b5dfd737